### PR TITLE
Update instructions for getpapers

### DIFF
--- a/textIndexing/solr/instructions.md
+++ b/textIndexing/solr/instructions.md
@@ -60,7 +60,7 @@ Solr uses the `bin/post` command to index documents.  You point the command at a
 
 Let's assume you are going to search for papers on COVID-19.  The following commands will retrieve papers and index them in Solr:
 ```bash
-getpapers -q  -x -p "COVID-19" -o getpapers/covid19 # the -x and -p switches download the fult text as XML and PDFs
+getpapers -q "COVID-19" -x -p -o getpapers/covid19 # the -x and -p switches download the fult text as XML and PDFs
 sudo su - solr -c "/opt/solr/bin/post -c getpapers /home/clyde/getpapers"
 ```
 Solr adds all the files in **getpapers** and subdirectories to its index.  If a file exists then it simply overwrites the index information.


### PR DESCRIPTION
The `q` and `p` flags were the wrong way around, leading to a query that matched all results.